### PR TITLE
chore(github): add kodiak auto-merge configuration

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,0 +1,17 @@
+version = 1
+
+[merge]
+require_automerge_label = false
+blocking_labels = ['blocked', 'in review', 'semver:major']
+method = 'squash'
+
+[merge.message]
+title = 'pull_request_title'
+strip_html_comments = true
+include_coauthors = true
+
+[merge.automerge_dependencies]
+# only auto merge "minor" and "patch" version upgrades.
+# do not automerge "major" version upgrades.
+versions = ["minor", "patch"]
+usernames = ["dependabot", "renovate"]


### PR DESCRIPTION
## Summary

- Adds [Kodiak](https://kodiakhq.com/) bot configuration to automate dependency PR merges
- Configures squash-merge strategy with PR title as the commit message
- Restricts auto-merge to `minor` and `patch` version bumps from Dependabot and Renovate; `major` upgrades require manual review via the `semver:major` blocking label

## Type of Change

- [x] Chore / configuration (no source code changes)

## Test Procedure

No code changes — verifiable by checking the Kodiak bot picks up the config after merging and begins processing eligible dependency PRs automatically.

## Pre-flight Checklist

- [x] Config reviewed for correctness (blocking labels, automerge scope)
- [x] No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal pull request automation configuration for improved merge workflow management.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->