### PR TITLE
feat(build): add dev tunnel and tsdown path aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ package-lock.json
 
 # Plans
 plans/
+
+# Pnpm store
+.pnpm-store

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN corepack enable
 COPY --chown=node:node pnpm-lock.yaml .
 COPY --chown=node:node pnpm-workspace.yaml .
 COPY --chown=node:node package.json .
-COPY --chown=node:node .npmrc .
 
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm fetch --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
 		"gradient-string": "^3.0.0",
 		"husky": "^9.1.7",
 		"nano-staged": "^1.0.2",
-		"tslib": "^2.8.1"
+		"tslib": "^2.8.1",
+		"untun": "^0.1.3"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^21.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
+      untun:
+        specifier: ^0.1.3
+        version: 0.1.3
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.0.2
@@ -1539,6 +1542,9 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
@@ -1595,6 +1601,10 @@ packages:
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   conventional-changelog-angular@8.3.1:
     resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
@@ -2370,6 +2380,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -2877,6 +2890,10 @@ packages:
     peerDependenciesMeta:
       synckit:
         optional: true
+
+  untun@0.1.3:
+    resolution: {integrity: sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==}
+    hasBin: true
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -4356,6 +4373,10 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
   cjs-module-lexer@1.4.3: {}
 
   cli-cursor@3.1.0:
@@ -4418,6 +4439,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.2.4: {}
+
+  consola@3.4.2: {}
 
   conventional-changelog-angular@8.3.1:
     dependencies:
@@ -5190,6 +5213,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
 
   perfect-debounce@2.1.0: {}
@@ -5676,6 +5701,12 @@ snapshots:
     optionalDependencies:
       synckit: 0.11.11
     optional: true
+
+  untun@0.1.3:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      pathe: 1.1.2
 
   uri-js@4.4.1:
     dependencies:

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,7 +1,7 @@
-import { config } from "dotenv";
+import { setup as envRun } from "@wolfstar/env-utilities";
 import { defineConfig, env } from "prisma/config";
 
-config({ path: ["src/.env.local", "src/.env"] });
+envRun(new URL("./src/.env", import.meta.url));
 export default defineConfig({
 	schema: "prisma/schema.prisma",
 	migrations: {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, cpSync } from "node:fs";
 import { resolve } from "node:path";
 import alias from "@rollup/plugin-alias";
 import { defineConfig } from "tsdown";
+import { startTunnel } from "untun";
 
 function resolveSource(base: string, subPath: string): string {
 	if (subPath.endsWith(".ts"))
@@ -13,6 +14,7 @@ function resolveSource(base: string, subPath: string): string {
 	return resolve(import.meta.dirname, base, subPath, "index.ts");
 }
 
+// Plugin to copy locales from src to dist
 function copyPlugin(): Rolldown.RolldownPluginOption {
 	return {
 		name: "copy-mjs-files",
@@ -24,6 +26,53 @@ function copyPlugin(): Rolldown.RolldownPluginOption {
 				mkdirSync(distLocalesDir, { recursive: true });
 				cpSync(srcDir, distLocalesDir, { recursive: true });
 				console.log("✓ Copied locales to dist");
+			}
+		},
+	};
+}
+
+const isTunnelEnabled =
+	process.argv.includes("--tunnel") ||
+	process.env["TUNNEL"] === "1" ||
+	process.env["TUNNEL"] === "true";
+
+function parsePort(value: string | undefined, fallback: number): number {
+	if (value === undefined) return fallback;
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		console.error(
+			`[dev-tunnel] Invalid HTTP_PORT "${value}", falling back to ${String(fallback)}`,
+		);
+		return fallback;
+	}
+	return parsed;
+}
+
+function startDevTunnel(): Rolldown.RolldownPluginOption {
+	let started = false;
+	return {
+		name: "dev-tunnel",
+		async buildEnd() {
+			if (!isTunnelEnabled || started) return;
+			const port = parsePort(process.env["HTTP_PORT"], 3000);
+			try {
+				const tunnel = await startTunnel({
+					port,
+					acceptCloudflareNotice: true,
+				});
+				if (!tunnel) {
+					console.error("[dev-tunnel] Failed to start tunnel");
+					return;
+				}
+				const url = await tunnel.getURL();
+				if (!url) {
+					console.error("[dev-tunnel] Tunnel started but URL was not assigned");
+					return;
+				}
+				console.log(`✓ Tunnel ready at ${url}`);
+				started = true;
+			} catch (error) {
+				console.error("[dev-tunnel] Tunnel startup failed:", error);
 			}
 		},
 	};
@@ -51,6 +100,16 @@ export default defineConfig({
 					),
 				},
 				{
+					find: "#i18n",
+					replacement: "#i18n",
+					customResolver(source) {
+						if (source === "#i18n")
+							return resolve(import.meta.dirname, "src/lib/i18n/index.ts");
+						const subPath = source.replace("#i18n/", "");
+						return resolveSource("src/lib/i18n", subPath);
+					},
+				},
+				{
 					find: "#api",
 					replacement: "#api",
 					customResolver(source) {
@@ -76,9 +135,18 @@ export default defineConfig({
 						return resolveSource("src/lib/types", subPath);
 					},
 				},
+				{
+					find: "#utils",
+					replacement: "#utils",
+					customResolver(source) {
+						const subPath = source.replace("#utils/", "");
+						return resolveSource("src/lib/utilities", subPath);
+					},
+				},
 			],
 		}),
 		copyPlugin(),
+		...(isTunnelEnabled ? [startDevTunnel()] : []),
 	],
 	dts: true,
 	unbundle: true,


### PR DESCRIPTION
## Summary

Improves local development and build tooling by adding an optional Cloudflare dev tunnel, filling in missing tsdown path aliases, aligning Prisma env loading with Staryl, and simplifying the Docker build stage.

## Changes

- **Dev tunnel**: Add `untun` and a tsdown plugin that starts a Cloudflare tunnel when `--tunnel` is passed or `TUNNEL=1`/`TUNNEL=true` is set. Uses `HTTP_PORT` (default 3000).
- **Tsdown aliases**: Register `#i18n` and `#utils` resolvers so dev/build bundling matches runtime import paths.
- **Prisma config**: Switch from `dotenv` to `@wolfstar/env-utilities` for env loading, consistent with Staryl.
- **Dockerfile**: Remove redundant `.npmrc` copy from the dependency fetch stage.

## Test plan

- [ ] `pnpm build` succeeds
- [ ] `pnpm lint` passes
- [ ] `TUNNEL=1 pnpm dev` prints a tunnel URL after build
- [ ] Docker image builds without the `.npmrc` copy step
