### PR TITLE
fix(ci): publish amd64 docker image for railway deployment

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -24,6 +24,22 @@ jobs:
     secrets: inherit
     with:
       enablePlatforms: true
-      platforms: >-
-        [{"platform": "linux/amd64", "runner": "ubuntu-latest"}, {"platform":
-        "linux/arm64", "runner": "ubuntu-latest"}]
+      # Native runners per arch — arm64 on ubuntu-latest uses QEMU and can produce
+      # images that never merge correctly with amd64 for Railway (linux/amd64).
+      platforms:
+        '[{"platform": "linux/amd64", "runner": "ubuntu-latest"}, {"platform":
+        "linux/arm64", "runner": "ubuntu-24.04-arm"}]'
+
+  verify:
+    name: Verify multi-arch manifest on GHCR
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Assert linux/amd64 is published
+        run: |
+          docker buildx imagetools inspect ghcr.io/wolfstar-project/ring:latest \
+            | tee /tmp/imagetools.txt
+          grep -q 'linux/amd64' /tmp/imagetools.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #   Base Stage     #
 # ================ #
 
-FROM node:24-alpine AS base
+FROM --platform=$TARGETPLATFORM node:24-alpine AS base
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Summary

Railway deploys on `linux/amd64`, but `ghcr.io/wolfstar-project/ring:latest` was published as a single-platform ARM64 image. The container entrypoint (`dumb-init`) fails immediately with `Exec format error` on every start.

This PR fixes the CD pipeline so the image is built on native runners per architecture and CI verifies that `linux/amd64` is present in the GHCR manifest before the workflow succeeds.

## Related issue

N/A — infrastructure fix from Railway deployment diagnosis.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Workflow / CI

## Changes

- **Dockerfile**: use `FROM --platform=$TARGETPLATFORM` so Alpine packages (including `dumb-init`) match the build target architecture.
- **continuous-delivery.yml**: build `linux/arm64` on `ubuntu-24.04-arm` instead of QEMU on `ubuntu-latest`; add a `verify` job that asserts `linux/amd64` is in the published manifest.

## Test plan

- [ ] Merge and let Continuous Delivery run on `main` (or trigger via workflow_dispatch).
- [ ] Confirm `docker buildx imagetools inspect ghcr.io/wolfstar-project/ring:latest` lists both `linux/amd64` and `linux/arm64`.
- [ ] Redeploy the `ring` service on Railway and confirm the container starts without `Exec format error`.

## Pre-flight checklist

- [x] Changes are scoped to the Docker / CD fix only
- [x] Conventional commit / PR title format
- [ ] CI checks pass after push

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/ring/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex compared the base and head Dockerfiles and CI definitions to confirm platform and manifest-related changes were introduced, including the new platform-specific FROM usage and the added manifest verification step.

<a href="https://app.greptile.com/trex/runs/13088986/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Push as Push to main / workflow_dispatch
participant CD as Continuous Delivery
participant Publish as reusable-publish-image
participant AMD as ubuntu-latest amd64 runner
participant ARM as ubuntu-24.04-arm runner
participant GHCR as GHCR manifest
participant Verify as verify job

Push->>CD: trigger workflow
CD->>Publish: platforms JSON
Publish->>AMD: build linux/amd64 image
Publish->>ARM: build linux/arm64 image
AMD-->>GHCR: publish amd64 image
ARM-->>GHCR: publish arm64 image
Publish-->>CD: publish complete
CD->>Verify: needs publish
Verify->>GHCR: docker buildx imagetools inspect latest
GHCR-->>Verify: manifest list
Verify->>Verify: assert linux/amd64 present
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Push as Push to main / workflow_dispatch
participant CD as Continuous Delivery
participant Publish as reusable-publish-image
participant AMD as ubuntu-latest amd64 runner
participant ARM as ubuntu-24.04-arm runner
participant GHCR as GHCR manifest
participant Verify as verify job

Push->>CD: trigger workflow
CD->>Publish: platforms JSON
Publish->>AMD: build linux/amd64 image
Publish->>ARM: build linux/arm64 image
AMD-->>GHCR: publish amd64 image
ARM-->>GHCR: publish arm64 image
Publish-->>CD: publish complete
CD->>Verify: needs publish
Verify->>GHCR: docker buildx imagetools inspect latest
GHCR-->>Verify: manifest list
Verify->>Verify: assert linux/amd64 present
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): publish amd64 docker image for ..."](https://github.com/wolfstar-project/ring/commit/72158864e3738b0b72ffa750de41eab454edeab6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41431746)</sub>

<!-- /greptile_comment -->