### PR TITLE
docs(agents): fix Cloud dev-environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,21 +27,22 @@ when the schema changes).
 `package.json` requires **Node >= 24**. Activate Node 24 before any `pnpm`
 command if the VM default is older.
 
-### Infrastructure (PostgreSQL)
+### Infrastructure (PostgreSQL + Redis)
 
-Start the database (once per VM session):
-
-```bash
-docker compose -f compose.dev.yml up postgres -d
-```
-
-Override in `src/.env.local` (gitignored):
+There is **no `compose.dev.yml`** in this repo and Docker is not installed on
+the Cloud VM. PostgreSQL 16 and Redis 7 are installed natively by the update
+script's sibling setup and are started manually (systemd is not running):
 
 ```bash
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/ring?schema=public"
+sudo pg_ctlcluster 16 main start          # Postgres on :5432
+redis-server --port 8287 --requirepass redis --daemonize yes   # Redis on :8287
 ```
 
-Apply migrations after Postgres is healthy:
+Postgres is seeded with role `postgres`/password `postgres` and database `ring`.
+Redis uses port `8287` and password `redis` (see `src/.env`). Redis connection
+errors are swallowed at the source, so the app boots even if Redis is down.
+
+Apply migrations after Postgres is healthy (once per DB):
 
 ```bash
 pnpm prisma:generate
@@ -50,9 +51,34 @@ pnpm exec prisma migrate deploy
 
 ### Environment variables
 
-Copy `src/.env` values into `src/.env.local` for local overrides. The HTTP
-framework requires non-empty `DISCORD_PUBLIC_KEY` and `DISCORD_TOKEN` to boot.
-`INTERNAL_API_STARYL_TOKEN` must match Staryl's `INTERNAL_RING_TOKEN`.
+Local overrides live in `src/.env.local` (gitignored); it is loaded with
+priority over `src/.env`. The HTTP framework requires non-empty
+`DISCORD_PUBLIC_KEY` and `DISCORD_TOKEN` to boot. `INTERNAL_API_STARYL_TOKEN`
+must match Staryl's `INTERNAL_RING_TOKEN`.
+
+**Gotcha — `DATABASE_URL` must be in the process env at launch.**
+`src/lib/setup/prisma.ts` builds the Prisma adapter from
+`process.env.DATABASE_URL` at module-import time, which runs _before_ the dotenv
+loader populates env from `src/.env*`. In production the orchestrator injects
+env vars; locally you must export it before starting, otherwise Prisma tries to
+connect to host `base`:
+
+```bash
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/ring?schema=public"
+```
+
+**Gotcha — placeholder Discord token crashes the process.** On boot
+`registerCommands()` pushes slash commands to Discord and throws `401` with
+placeholder credentials; the unhandled rejection would tear down the (already
+listening) servers. To keep the API/HTTP servers alive for local testing without
+real Discord credentials, run with:
+
+```bash
+export NODE_OPTIONS="--enable-source-maps --unhandled-rejections=warn"
+```
+
+With real `DISCORD_TOKEN`/`DISCORD_CLIENT_ID`/`DISCORD_PUBLIC_KEY` this is
+unnecessary.
 
 ### Running the app
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Ring development environment on the Cursor Cloud VM, and corrects the `## Cursor Cloud specific instructions` in `AGENTS.md` which referenced a non-existent `compose.dev.yml` and Docker (not installed on the VM).

## What was set up

- **Node 24** via `nvm` (repo requires `>=24`; VM default was v22), with `corepack`-activated `pnpm@11.8.0`.
- **Dependencies** via `pnpm install --frozen-lockfile` + `pnpm prisma:generate`.
- **PostgreSQL 16** (native) with role `postgres`/`postgres` and database `ring`; migrations applied via `prisma migrate deploy`.
- **Redis 7** (native) on port `8287` with password `redis`.
- `src/.env.local` (gitignored) with `DATABASE_URL`, placeholder Discord keys, and internal API tokens.

## AGENTS.md corrections (only committed change)

- Replaced the `docker compose -f compose.dev.yml` step with native Postgres/Redis start commands.
- Documented two non-obvious boot gotchas discovered during setup:
  - `DATABASE_URL` must be exported into the process env before launch (the Prisma adapter is built at module-import time, before dotenv loads — otherwise it tries to connect to host `base`).
  - The placeholder Discord token makes `registerCommands()` throw `401`; run with `NODE_OPTIONS=--unhandled-rejections=warn` locally to keep the servers alive without real credentials.

## Verification (lint / build / run)

- `pnpm lint` — passes (oxlint + oxfmt).
- `pnpm build` — succeeds (tsdown).
- `pnpm start` — both servers listen: Discord HTTP interactions `:3000`, Fastify internal API `:3001`; banner prints `Ready`, 2 commands loaded.

### Hello-world (end-to-end DB round-trip)

Wrote a guild row to Postgres (`youtube=9, twitch=18, words=175`) and read it back through the authenticated internal API:

```
GET /                              -> {"data":"Hello world"}                       200
GET /guilds/<id>   (no auth)       -> Missing authorization                        401
GET /guilds/<id>   (bad token)     -> Missing access to this resource              403
GET /guilds/<id>   (staryl token)  -> {"maximumYouTubeSubscriptions":9,"maximumTwitchSubscriptions":18}   200
GET /guilds/<id>   (wolfstar)      -> {"maximumFilteredWords":175,...}             200
GET /experiments   (staryl token)  -> {"page":1,"totalPages":1,"total":0,...}      200
```

There is no automated test suite; CI runs `pnpm lint` and `pnpm build` only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca4efcb7-2f21-4600-9f68-10557b192d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca4efcb7-2f21-4600-9f68-10557b192d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/ring/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787413828&installation_model_id=425462&pr_number=93&repository=wolfstar-project%2Fring&return_to=https%3A%2F%2Fgithub.com%2Fwolfstar-project%2Fring%2Fpull%2F93&signature=1547252b6a6e452cc58fdc6a79fc47eaa80626fdf9526601ab6d8e247907f89a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The documented local override path needs correction before merging.

- Native service settings match the repository defaults.
- The database import-order warning matches the startup path.
- `src/.env.local` values are not loaded as documented, so credentials and tokens can be silently ignored.

AGENTS.md
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AAGENTS.md%3A54-55%0A**Local%20Overrides%20Are%20Ignored**%0A%0AThe%20startup%20path%20loads%20%60src%2F.env%60%20explicitly%20and%20does%20not%20load%20%60src%2F.env.local%60.%20An%20agent%20following%20this%20instruction%20can%20place%20Discord%20credentials%20or%20internal%20API%20tokens%20in%20%60.env.local%60%2C%20but%20the%20app%20will%20still%20use%20the%20defaults%20from%20%60.env%60%2C%20causing%20command%20registration%20or%20authenticated%20API%20requests%20to%20fail.%0A%0A&repo=wolfstar-project%2Fring&pr=93&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AAGENTS.md%3A54-55%0A**Local%20Overrides%20Are%20Ignored**%0A%0AThe%20startup%20path%20loads%20%60src%2F.env%60%20explicitly%20and%20does%20not%20load%20%60src%2F.env.local%60.%20An%20agent%20following%20this%20instruction%20can%20place%20Discord%20credentials%20or%20internal%20API%20tokens%20in%20%60.env.local%60%2C%20but%20the%20app%20will%20still%20use%20the%20defaults%20from%20%60.env%60%2C%20causing%20command%20registration%20or%20authenticated%20API%20requests%20to%20fail.%0A%0A&pr=93&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22wolfstar-project%2Fring%22%20on%20the%20existing%20branch%20%22cursor%2Fsetup-dev-environment-2d3f%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fsetup-dev-environment-2d3f%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AAGENTS.md%3A54-55%0A**Local%20Overrides%20Are%20Ignored**%0A%0AThe%20startup%20path%20loads%20%60src%2F.env%60%20explicitly%20and%20does%20not%20load%20%60src%2F.env.local%60.%20An%20agent%20following%20this%20instruction%20can%20place%20Discord%20credentials%20or%20internal%20API%20tokens%20in%20%60.env.local%60%2C%20but%20the%20app%20will%20still%20use%20the%20defaults%20from%20%60.env%60%2C%20causing%20command%20registration%20or%20authenticated%20API%20requests%20to%20fail.%0A%0A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=wolfstar-project%2Fring&uid=108079&ts=1784821958&sig=71cf4a5f9b6b8aa51f2044baab2c85ffbc7e1808695dadb558959cec6ecc06f0&pr=93&platform=github&fid=0ba6b824-4fcc-47fe-8c23-f3bbbf228f0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
AGENTS.md:54-55
**Local Overrides Are Ignored**

The startup path loads `src/.env` explicitly and does not load `src/.env.local`. An agent following this instruction can place Discord credentials or internal API tokens in `.env.local`, but the app will still use the defaults from `.env`, causing command registration or authenticated API requests to fail.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): correct cloud setup for na..."](https://github.com/wolfstar-project/ring/commit/7b4a332a7c4c30784310792088594babc29beb3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46705817)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/wolfstar-project/github/wolfstar-project/ring/-/custom-context?memory=6b49606f-cf0a-4008-8995-65ebcf8dce3a))
- Context used - AGENTS.md ([source](https://app.greptile.com/wolfstar-project/github/wolfstar-project/ring/-/custom-context?memory=36d599e4-1730-4c9b-ad9c-6d9eeb8bd262))

<!-- /greptile_comment -->