### PR TITLE
ci: switch GitHub Actions runners to Depot

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -22,3 +22,5 @@ jobs:
     name: Publish Ring Latest image to GHCR
     uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@main
     secrets: inherit
+    with:
+      depotProject: pwlngzmhmr

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   lint:
     name: 🔠 Lint project
-    runs-on: ubuntu-24.04-arm
+    runs-on: depot-ubuntu-24.04-arm-4
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -42,7 +42,7 @@ jobs:
 
   build:
     name: � Build project
-    runs-on: ubuntu-24.04-arm
+    runs-on: depot-ubuntu-24.04-arm-4
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary
- Move CI runners from `ubuntu-24.04-arm` to `depot-ubuntu-24.04-arm-4` (Ring never used Blacksmith, this aligns it with the rest of the org).
- Pass `depotProject: pwlngzmhmr` to the shared `reusable-publish-image.yml` workflow (now Depot-based) for the Docker publish job.

## Test plan
- [ ] Confirm the Depot GitHub App is installed on the `wolfstar-project` org
- [ ] Watch CI on this PR to confirm jobs are picked up by Depot runners
- [ ] Watch a Docker publish run to confirm the image builds/pushes via Depot

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/ring/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The workflow changes are internally consistent with the stated Depot migration, and the available repository evidence does not establish an invalid reusable-workflow input, incompatible job environment, or newly introduced secrets exposure.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: switch GitHub Actions runners to Dep..."](https://github.com/wolfstar-project/ring/commit/881c56741753e665ad9a6f7e6160aefabe2ac45b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47421093)</sub>

<!-- /greptile_comment -->