### PR TITLE
style(routes): match skyra's early-return response pattern

### DIFF
--- a/src/routes/experiments/[key]/index.delete.ts
+++ b/src/routes/experiments/[key]/index.delete.ts
@@ -14,7 +14,7 @@ export class ExperimentDeleteRoute extends Route {
 		const key = request.params.key;
 
 		if (request.query.get("confirm") !== key) {
-			response.json(
+			return response.json(
 				{
 					success: false,
 					message:
@@ -22,18 +22,17 @@ export class ExperimentDeleteRoute extends Route {
 				},
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		try {
 			await container.experiments.delete(key);
-			response.json(
+			return response.json(
 				{ success: true, message: `Deleted experiment \`${key}\`.` },
 				HttpCodes.OK,
 			);
 		} catch (error) {
 			container.logger.error(error);
-			response.json(
+			return response.json(
 				{ success: false, message: "That experiment does not exist." },
 				HttpCodes.NotFound,
 			);

--- a/src/routes/experiments/[key]/index.get.ts
+++ b/src/routes/experiments/[key]/index.get.ts
@@ -17,15 +17,14 @@ export class ExperimentRoute extends Route {
 
 		const experiment = await container.experiments.findById(key);
 		if (isNullish(experiment)) {
-			response.json(
+			return response.json(
 				{ success: false, message: "That experiment does not exist." },
 				HttpCodes.NotFound,
 			);
-			return;
 		}
 
 		const overrideCount = await container.experiments.countOverrides(key);
-		response.json(
+		return response.json(
 			{ ...serializeExperiment(experiment), overrideCount },
 			HttpCodes.OK,
 		);

--- a/src/routes/experiments/[key]/index.patch.ts
+++ b/src/routes/experiments/[key]/index.patch.ts
@@ -27,29 +27,26 @@ export class ExperimentUpdateRoute extends Route {
 		try {
 			body = await request.readBodyJson<Record<string, unknown>>();
 		} catch {
-			response.json(
+			return response.json(
 				{ success: false, message: "Missing request body" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 		if (isNullish(body) || typeof body !== "object" || Array.isArray(body)) {
-			response.json(
+			return response.json(
 				{ success: false, message: "The request body must be a JSON object" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const endDate = parseEditableDate(
 			readStringField(body, "end-date", "endDate"),
 		);
 		if (endDate === InvalidDate) {
-			response.json(
+			return response.json(
 				{ success: false, message: "The provided end date is invalid." },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		// A concrete new end date must not fall before the stored start date,
@@ -57,17 +54,16 @@ export class ExperimentUpdateRoute extends Route {
 		if (endDate instanceof Date) {
 			const existing = await container.experiments.findById(key);
 			if (isNullish(existing)) {
-				response.json(
+				return response.json(
 					{
 						success: false,
 						message: "That experiment does not exist.",
 					},
 					HttpCodes.NotFound,
 				);
-				return;
 			}
 			if (existing.startDate && endDate < existing.startDate) {
-				response.json(
+				return response.json(
 					{
 						success: false,
 						message:
@@ -75,7 +71,6 @@ export class ExperimentUpdateRoute extends Route {
 					},
 					HttpCodes.BadRequest,
 				);
-				return;
 			}
 		}
 
@@ -90,10 +85,10 @@ export class ExperimentUpdateRoute extends Route {
 
 		try {
 			const experiment = await container.experiments.update(key, data);
-			response.json(serializeExperiment(experiment), HttpCodes.OK);
+			return response.json(serializeExperiment(experiment), HttpCodes.OK);
 		} catch (error) {
 			container.logger.error(error);
-			response.json(
+			return response.json(
 				{ success: false, message: "That experiment does not exist." },
 				HttpCodes.NotFound,
 			);

--- a/src/routes/experiments/[key]/overrides/[entityType]/[entityId].delete.ts
+++ b/src/routes/experiments/[key]/overrides/[entityType]/[entityId].delete.ts
@@ -16,14 +16,13 @@ export class ExperimentOverrideDeleteRoute extends Route {
 
 		const entityType = toOverrideEntityType(request.params.entityType);
 		if (entityType === null) {
-			response.json(
+			return response.json(
 				{
 					success: false,
 					message: "Entity type must be one of guild or user",
 				},
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const count = await container.experiments.removeOverride(
@@ -35,6 +34,6 @@ export class ExperimentOverrideDeleteRoute extends Route {
 			count === 0
 				? "There was no override to remove."
 				: `Removed the override for \`${entityId}\`.`;
-		response.json({ success: true, count, message }, HttpCodes.OK);
+		return response.json({ success: true, count, message }, HttpCodes.OK);
 	}
 }

--- a/src/routes/experiments/[key]/overrides/index.post.ts
+++ b/src/routes/experiments/[key]/overrides/index.post.ts
@@ -24,41 +24,37 @@ export class ExperimentOverrideCreateRoute extends Route {
 		try {
 			body = await request.readBodyJson<Record<string, unknown>>();
 		} catch {
-			response.json(
+			return response.json(
 				{ success: false, message: "Missing request body" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 		if (typeof body !== "object" || isNullish(body) || Array.isArray(body)) {
-			response.json(
+			return response.json(
 				{ success: false, message: "Missing request body" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const entityType = toOverrideEntityType(
 			readStringField(body, "entity-type", "entityType"),
 		);
 		if (entityType === null) {
-			response.json(
+			return response.json(
 				{
 					success: false,
 					message: "Entity type must be one of guild or user",
 				},
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const entityId = readStringField(body, "entity-id", "entityId");
 		if (isNullishOrEmpty(entityId)) {
-			response.json(
+			return response.json(
 				{ success: false, message: "Missing entity ID" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const rawBucket = body.bucket;
@@ -67,14 +63,13 @@ export class ExperimentOverrideCreateRoute extends Route {
 				? toBucketValue(rawBucket)
 				: null;
 		if (bucket === null) {
-			response.json(
+			return response.json(
 				{
 					success: false,
 					message: "A valid bucket is required when setting an override.",
 				},
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		// Reject overrides whose entity type does not match the experiment's
@@ -82,24 +77,22 @@ export class ExperimentOverrideCreateRoute extends Route {
 		// would silently never apply. `BOTH` accepts either entity type.
 		const experiment = await container.experiments.findById(key);
 		if (isNullish(experiment)) {
-			response.json(
+			return response.json(
 				{ success: false, message: "That experiment does not exist." },
 				HttpCodes.NotFound,
 			);
-			return;
 		}
 		if (
 			experiment.entityType !== "BOTH" &&
 			experiment.entityType !== entityType
 		) {
-			response.json(
+			return response.json(
 				{
 					success: false,
 					message: `This experiment targets ${experiment.entityType.toLowerCase()} entities; a ${entityType.toLowerCase()} override would never apply.`,
 				},
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const createdBy =
@@ -114,10 +107,10 @@ export class ExperimentOverrideCreateRoute extends Route {
 				reason: normalizeOptional(readStringField(body, "reason")) ?? null,
 				createdBy,
 			});
-			response.json(override, HttpCodes.OK);
+			return response.json(override, HttpCodes.OK);
 		} catch (error) {
 			container.logger.error(error);
-			response.json(
+			return response.json(
 				{
 					success: false,
 					message: "That experiment does not exist.",

--- a/src/routes/experiments/[key]/resolve.get.ts
+++ b/src/routes/experiments/[key]/resolve.get.ts
@@ -16,20 +16,18 @@ export class ExperimentResolveRoute extends Route {
 
 		const entityType = request.query.get("entityType");
 		if (entityType !== "guild" && entityType !== "user") {
-			response.json(
+			return response.json(
 				{ success: false, message: "Invalid entity type" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const entityId = request.query.get("entityId");
 		if (isNullishOrEmpty(entityId)) {
-			response.json(
+			return response.json(
 				{ success: false, message: "Missing entity ID" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const botId = request.query.get("botId");
@@ -42,6 +40,6 @@ export class ExperimentResolveRoute extends Route {
 				botId,
 			},
 		);
-		response.json(result, HttpCodes.OK);
+		return response.json(result, HttpCodes.OK);
 	}
 }

--- a/src/routes/experiments/index.get.ts
+++ b/src/routes/experiments/index.get.ts
@@ -58,7 +58,7 @@ export class ExperimentsListRoute extends Route {
 		]);
 
 		const totalPages = Math.max(1, Math.ceil(total / ExperimentsPerPage));
-		response.json(
+		return response.json(
 			{
 				page,
 				totalPages,

--- a/src/routes/experiments/index.post.ts
+++ b/src/routes/experiments/index.post.ts
@@ -26,37 +26,33 @@ export class ExperimentsCreateRoute extends Route {
 		try {
 			body = await request.readBodyJson<Record<string, unknown>>();
 		} catch {
-			response.json(
+			return response.json(
 				{ success: false, message: "Missing request body" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 		if (typeof body !== "object" || isNullish(body) || Array.isArray(body)) {
-			response.json(
+			return response.json(
 				{ success: false, message: "Missing request body" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const name = typeof body.name === "string" ? body.name.trim() : "";
 		if (isNullishOrEmpty(name)) {
-			response.json(
+			return response.json(
 				{ success: false, message: "A name is required" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const category =
 			typeof body.category === "string" ? body.category.trim() : "";
 		if (isNullishOrEmpty(category)) {
-			response.json(
+			return response.json(
 				{ success: false, message: "A category is required" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const rawEntityType = readStringField(body, "entity-type", "entityType");
@@ -65,14 +61,13 @@ export class ExperimentsCreateRoute extends Route {
 			rawEntityType !== "user" &&
 			rawEntityType !== "both"
 		) {
-			response.json(
+			return response.json(
 				{
 					success: false,
 					message: "Entity type must be one of guild, user, or both",
 				},
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const startDate = parseDate(
@@ -80,24 +75,22 @@ export class ExperimentsCreateRoute extends Route {
 		);
 		const endDate = parseDate(readStringField(body, "end-date", "endDate"));
 		if (startDate === InvalidDate || endDate === InvalidDate) {
-			response.json(
+			return response.json(
 				{
 					success: false,
 					message: "One of the provided dates is invalid.",
 				},
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 		if (startDate && endDate && endDate < startDate) {
-			response.json(
+			return response.json(
 				{
 					success: false,
 					message: "The end date cannot be before the start date.",
 				},
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const rollout =
@@ -129,10 +122,10 @@ export class ExperimentsCreateRoute extends Route {
 				createdBy,
 				botId,
 			});
-			response.json(serializeExperiment(experiment), HttpCodes.Created);
+			return response.json(serializeExperiment(experiment), HttpCodes.Created);
 		} catch (error) {
 			container.logger.error(error);
-			response.json(
+			return response.json(
 				{
 					success: false,
 					message: `Could not create the experiment. A flag with the key \`${id}\` may already exist.`,

--- a/src/routes/guilds/[id].get.ts
+++ b/src/routes/guilds/[id].get.ts
@@ -15,17 +15,16 @@ export class GuildRoute extends Route {
 		try {
 			id = BigInt(request.params.id);
 		} catch {
-			response.json(
+			return response.json(
 				{ success: false, message: "Invalid Guild ID" },
 				HttpCodes.BadRequest,
 			);
-			return;
 		}
 
 		const data = await container.prisma.guild.findFirst({
 			where: { id },
 			select: request.mappings.properties,
 		});
-		response.json(data ?? request.mappings.defaults, HttpCodes.OK);
+		return response.json(data ?? request.mappings.defaults, HttpCodes.OK);
 	}
 }

--- a/src/routes/index.get.ts
+++ b/src/routes/index.get.ts
@@ -8,6 +8,6 @@ export class HelloRoute extends Route {
 	}
 
 	public run(_request: ApiRequest, response: ApiResponse) {
-		response.json({ data: "Hello world" }, HttpCodes.OK);
+		return response.json({ data: "Hello world" }, HttpCodes.OK);
 	}
 }


### PR DESCRIPTION
## Summary

Aligns `src/routes` with the code style used by [skyra's routes](https://github.com/skyra-project/skyra/tree/main/src/routes): every route handler now always returns its response call (`return response.json(...)`) instead of splitting it into a bare `response.json(...)` statement followed by a separate `return;`.

This is a purely mechanical, non-behavioral formatting change — no response bodies, status codes, or control flow branches were altered.

- All 10 files under `src/routes` updated (`index.get.ts`, `guilds/[id].get.ts`, and all `experiments/**` routes)
- `pnpm lint` and `pnpm build` both pass

## Test plan

- [x] `pnpm lint` — oxlint + oxfmt --check pass
- [x] `pnpm build` — tsdown build completes with no type errors
- [x] Manually diffed every changed route file to confirm only the `response.json(...); return;` → `return response.json(...);` transform was applied, with no other logic changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/ring/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Identified a persistent blocker caused by infrastructure/tool transport failure in the route return-contract validation harness.
- Tried to run the greptile-review\_multibash command runner; the sole retry returned Not connected, with no process started and no command-output artifact produced.

<a href="https://app.greptile.com/trex/runs/16793444/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["style(routes): use early-return response..."](https://github.com/wolfstar-project/ring/commit/e4ffa3f91d9d8985dfe760feaa512c2e992ecd60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49094822)</sub>

<!-- /greptile_comment -->